### PR TITLE
More vmem-related changes

### DIFF
--- a/iceberg/software/apps/bcbio.rst
+++ b/iceberg/software/apps/bcbio.rst
@@ -79,7 +79,7 @@ The GATK .jar file was obtained from https://www.broadinstitute.org/gatk/downloa
 A further upgrade was performed on 13th January 2016. STAR had to be run directly because the bcbio upgrade command that made use of it kept stalling ( `bcbio_nextgen.py upgrade --data --genomes GRCh37 --aligners bwa --aligners star` ). We have no idea why this made a difference but at least the direct STAR run could make use of multiple cores whereas the bcbio installer only uses 1 ::
 
   #!/bin/bash
-  #$ -l rmem=3G -l mem=3G
+  #$ -l rmem=3G 
   #$ -P radiant
   #$ -pe openmp 16
 
@@ -185,7 +185,6 @@ The following test script was submitted to the system as an SGE batch script ::
 
   #!/bin/bash
   #$ -pe openmp 12
-  #$ -l mem=4G  #Per Core!
   #$ -l rmem=4G #Per Core!
 
   module add apps/gcc/5.2/bcbio/0.9.6a
@@ -215,7 +214,6 @@ The following test script was submitted to the system. All tests passed. The out
 
   #!/bin/bash
   #$ -pe openmp 12
-  #$ -l mem=4G  #Per Core!
   #$ -l rmem=4G #Per Core!
 
   module add apps/gcc/5.2/bcbio/0.9.6a

--- a/iceberg/software/apps/bless.rst
+++ b/iceberg/software/apps/bless.rst
@@ -30,7 +30,7 @@ Here is an example batch submission script that makes use of two example input f
 
     #!/bin/bash
     # Next line is memory per slot
-    #$ -l mem=5G -l rmem=5G
+    #$ -l rmem=5G
     # Ask for 4 slots in an OpenMP/MPI Hybrid queue
     # These 4 slots will all be on the same node
     #$ -pe openmpi-hybrid-4 4

--- a/iceberg/software/apps/igv.rst
+++ b/iceberg/software/apps/igv.rst
@@ -10,9 +10,9 @@ The Integrative Genomics Viewer (IGV) is a high-performance visualization tool f
 
 Interactive Usage
 -----------------
-After connecting to Iceberg (see :ref:`ssh`),  start an graphical interactive session with the `qsh` command. In testing, we determined that you need to request at least 7 Gigabytes of memory to launch IGV ::
+After connecting to Iceberg (see :ref:`ssh`),  start an graphical interactive session with the `qsh` command. In testing, we determined that you need to request at least 7 Gigabytes of real memory to launch IGV ::
 
-       qsh -l mem=7G
+       qsh -l rmem=7G
 
 The latest version of IGV (currently 2.3.63) is made available with the command
 

--- a/iceberg/software/apps/intel_r.rst
+++ b/iceberg/software/apps/intel_r.rst
@@ -60,7 +60,7 @@ Here is how to run the R script called ``linear_algebra_bench.r`` from the `HPC 
    #!/bin/bash
    #This script runs the linear algebra benchmark multiple times using the intel-compiled version of R
    #that's linked with the sequential MKL
-   #$ -l mem=8G -l rmem=8G
+   #$ -l rmem=8G
    # Target the Ivy Bridge Processors
    #$ -l arch=intel-e5-2650v2
  
@@ -74,7 +74,7 @@ Here is how to run the same code using 8 cores:
 .. code-block:: bash
 
    #!/bin/bash
-   #$ -l mem=3G -l rmem=3G      # Memory per core
+   #$ -l rmem=3G # Memory per core
    # Target the Ivy Bridge Processors
    #$ -l arch=intel-e5-2650v2
    #$ -pe openmp 8

--- a/iceberg/software/apps/java.rst
+++ b/iceberg/software/apps/java.rst
@@ -42,6 +42,12 @@ Now, the compiler ::
 
 Virtual Memory
 --------------
+
+.. note::
+
+   The following is only relevant when revisiting older job submission scripts and documentation 
+   as the job scheduler :ref:`now polices jobs using real memory, not virtual memory <real-vs-virt-mem>`.
+
 By default, Java requests a lot of *virtual memory* on startup.
 This is usually a given fraction of the *physical memory* on a node,
 which can be quite a lot on Iceberg.

--- a/iceberg/software/apps/picard.rst
+++ b/iceberg/software/apps/picard.rst
@@ -12,7 +12,7 @@ Interactive Usage
 -----------------
 After connecting to Iceberg (see :ref:`ssh`),  start an interactive session with the :ref:`qrshx` or :ref:`qrsh` command, preferably requesting at least 8 Gigabytes of memory ::
 
-    qrsh -l mem=8G -l rmem=8G
+    qrsh -l rmem=8G
 
 The latest version of Picard (currently 1.129) is made available with the command ::
 

--- a/iceberg/software/apps/velvet.rst
+++ b/iceberg/software/apps/velvet.rst
@@ -23,17 +23,16 @@ This makes two programs available:-
 
 Example submission script
 -------------------------
-If the command you want to run is `velvetg /fastdata/foo1bar/velvet/assembly_31 -exp_cov auto -cov_cutoff auto`, here is an example submission script that requests 60Gig memory ::
+If the command you want to run is ``velvetg /fastdata/foo1bar/velvet/assembly_31 -exp_cov auto -cov_cutoff auto``, here is an example submission script that requests 60 GB of memory ::
 
   #!/bin/bash
-  #$ -l mem=60G
   #$ -l rmem=60G
 
   module load apps/gcc/4.4.7/velvet/1.2.10
 
   velvetg /fastdata/foo1bar/velvet/assembly_31 -exp_cov auto -cov_cutoff auto
 
-Put the above into a text file called `submit_velvet.sh` and submit it to the queue with the command `qsub submit_velvet.sh`
+Put the above into a text file called ``submit_velvet.sh`` and submit it to the queue with the command ``qsub submit_velvet.sh``
 
 Velvet Performance
 ------------------

--- a/iceberg/software/libs/FLAMEGPU.rst
+++ b/iceberg/software/libs/FLAMEGPU.rst
@@ -21,7 +21,7 @@ To install FLAME GPU you should checkout the latest master branch of the code wh
 
 To compile the FLAME GPU examples you will need to be on a GPU node. You can start an interactive session using ::
 
-    qsh -l gpu=1 -P gpu --l gpu_arch=nvidia-k40m -l mem=13G
+    qsh -l gpu=1 --l gpu_arch=nvidia-k40m -l rmem=13G
 
 You will then need to load the relevant modules ::
 

--- a/iceberg/software/libs/med.rst
+++ b/iceberg/software/libs/med.rst
@@ -50,7 +50,7 @@ The following was submiited as an SGE job from the med-3.0.8 build directory
 	#!/bin/bash
 
 	#$ -pe openmpi-ib 8
-	#$ -l mem=6G
+	#$ -l rmem=6G
 
 	module load mpi/gcc/openmpi/1.8.3
 	make check

--- a/parallel/Hybrid.rst
+++ b/parallel/Hybrid.rst
@@ -24,12 +24,11 @@ Here is an example job submission for an executable that combines SMP (specifica
 
   #$ -pe openmpi-hybrid-4 8
   #$ -l rmem=2G
-  #$ -l mem=6G
   module load mpi/intel/openmpi
   export OMP_NUM_THREADS=4
   mpirun -bynode -np 2 -cpus-per-proc 4 [executable + options]
 
-There would be 2 MPI processes running, each with 4x (6GB mem, 2GB rmem) shared between the four threads per MPI process, for a total of 8 x (6GB mem, 2GB rmem) for the entire job.
+There would be 2 MPI processes running, each with 4x 2GB of real memory shared between the four threads per MPI process, for a total of 8 x 2GB of real memory for the entire job.
 When we tried this, we got warnings saying that the `-cpus-per-proc` was getting deprecated.  A quick google suggests that ::
 
   mpirun -np 2 --map-by node:pe=1 [executable + options]

--- a/parallel/SMP.rst
+++ b/parallel/SMP.rst
@@ -61,7 +61,7 @@ You can start an interactive SMP job on ShARC like so: ::
 
 Or like so on Iceberg: ::
 
-        qrsh -pe openmp 4 -l mem=3G,rmem=3G
+        qrsh -pe openmp 4 -l rmem=3G
 
 .. note:: 
     It may be difficult to start an interactive SMP session if the cluster(s) are busy. 

--- a/sharc/software/libs/FLAMEGPU.rst
+++ b/sharc/software/libs/FLAMEGPU.rst
@@ -20,7 +20,7 @@ To install FLAME GPU you should checkout the latest master branch of the code wh
 
 To compile the FLAME GPU examples you will need to be on a GPU node. You can start an interactive session using ::
 
-    qrshx -l gpu=1 -P gpu -l mem=13G
+    qrshx -l gpu=1 -P gpu -l rmem=13G
 
 You will then need to load the relevant modules ::
 

--- a/troubleshooting.rst
+++ b/troubleshooting.rst
@@ -78,30 +78,49 @@ If a job exceeds its real memory resource it gets terminated. You can use the ``
 
 .. _real-vs-virt-mem:
 
-What is rmem (real memory) and mem (virtual memory)
------------------------------------------------------
+What are the rmem (real memory) and (deprecated) mem (virtual memory) options?
+------------------------------------------------------------------------------
 
-Running a program always involves loading the program instructions and also its data i.e. all variables and arrays that it uses into the computer's memory.
-A program's entire instructions and its entire data, along with any dynamic link libraries it may use, defines the **virtual storage** requirements of that program.
+.. warning::
+ 
+   The following is most likely only of interest when revisiting job submission scripts and documentation created before
+   26 June 2017 as now users only need to request real memory (``rmem``) and jobs are only killed if they exceed their ``rmem`` quota 
+   (whereas prior to that date jobs could request and be policed using virtual memory ``mem`` requests).
+
+Running a program always involves loading the program instructions and also its data (i.e. all variables and arrays that it uses) into the computer's memory.
+A program's entire instructions and its entire data, along with any dynamically-linked libraries it may use, defines the **virtual storage** requirements of that program.
 If we did not have clever operating systems we would need as much physical memory (RAM) as the virtual storage requirements of that program.
-However, operating systems are clever enough to deal with situations where we have insufficient **real memory** (physical memory, typically called RAM) to load all the program instructions and data into the available RAM. This technique works because hardly any program needs to access all its instructions and its data simultaneously. Therefore the operating system loads into RAM only those bits (**pages**) of the instructions and data that are needed by the program at a given instance. This is called **paging** and it involves copying bits of the programs instructions and data to/from hard-disk to RAM as they are needed.
+However, operating systems are clever enough to deal with situations where we have insufficient **real memory** (physical memory, typically called RAM) to 
+load all the program instructions and data into the available RAM. 
+This technique works because hardly any program needs to access all its instructions and its data simultaneously. 
+Therefore the operating system loads into RAM only those bits (**pages**) of the instructions and data that are needed by the program at a given instance. 
+This is called **paging** and it involves copying bits of the programs instructions and data to/from hard-disk to RAM as they are needed.
 
-If the real memory (i.e. RAM) allocated to a job is much smaller than the entire memory requirements of a job ( i.e. virtual memory) then there will be excessive need for paging that will slow the execution of the program considerably due to the relatively slow speeds of transferring information to/from the disk into RAM.
+If the real memory (i.e. RAM) allocated to a job is much smaller than the entire memory requirements of a job ( i.e. virtual memory) 
+then there will be excessive need for paging that will slow the execution of the program considerably due to 
+the relatively slow speeds of transferring information to/from the disk into RAM.
 
-On the other hand if the RAM allocated to a job is larger than the virtual memory requirement of that job then it will result in waste of RAM resources which will be idle duration of that job.
+On the other hand if the RAM allocated to a job is larger than the virtual memory requirement of that job then 
+it will result in waste of RAM resources which will be idle duration of that job.
 
 * The virtual memory limit defined by the ``-l mem`` cluster scheduler parameter defines the maximum amount of virtual memory your job will be allowed to use. **This option is now deprecated** - you can continue to submit jobs requesting virtual memory, however the scheduler **no longer applies any limits to this resource**.
 * The real memory limit is defined by the ``-l rmem`` cluster scheduler parameter and defines the amount of RAM that will be allocated to your job.  The job scheduler will terminate jobs which exceed their real memory resource request.
 
+.. note::
+ 
+   As mentioned above, jobs now need to just request real memory and are policed using real memory usage.  The reasons for this are:
+
+   * For best performance it is preferable to request as much real memory as the virtual memory storage requirements of a program as paging impacts on performance and memory is (relatively) cheap.
+   * Real memory is more tangible to newer users.
 
 Insufficient memory in an interactive session
 ---------------------------------------------
 By default, an interactive session provides you with 2 Gigabytes of RAM (sometimes called real memory).
-You can request more than this when running your ``qsh`` or ``qrsh`` command: ::
+You can request more than this when running your ``qrshx``/``qsh``/``qrsh`` command e.g.: ::
 
-        qsh  -l rmem=8G
+        qrshx -l rmem=8G
 
-This asks for 8 Gigabytes of RAM (real memory). Note that you should
+This asks for 8 Gigabytes of RAM (real memory). Note that you should:
 
 * not specify more than 256 GB of RAM (real memory) (``rmem``)
 
@@ -126,7 +145,9 @@ If you know the node that a program was compiled on but do not know the CPU arch
 
 Windows-style line endings
 --------------------------
-If you prepare text files such as your job submission script on a Windows machine, you may find that they do not work as intended on the system. A very common example is when a job immediately goes into ``Eqw`` status after you have submitted it.
+If you prepare text files such as your job submission script on a Windows machine, you may find that they do not work as intended on the system. A very common example is when a job immediately goes into ``Eqw`` status after you have submitted it and you are presented with an error message containing: ::
+
+        failed searching requested shell because:
 
 The reason for this behaviour is that Windows and Unix machines have different conventions for specifying 'end of line' in text files. Windows uses the control characters for 'carriage return' followed by 'linefeed', ``\r\n``, whereas Unix uses just 'linefeed' ``\n``.
 


### PR DESCRIPTION
* Remove more references to the `mem` complex 
* mark sections mentioning `mem` as being of historic interest only
* left mentions of `mem` complex in (most) 'testing' sections and install scripts as that's how things were tested. 